### PR TITLE
separate hindi and urdu as different languages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,8 @@ The Coding Garden community has people that speak many different languages! You 
 * [x] Slovenian
 * [x] Russian
 * [x] Macedonian
-* [ ] Hindi-Urdu
+* [ ] Hindi
+* [ ] Urdu
 * [ ] French
 * [ ] Italian
 * [x] Turkish


### PR DESCRIPTION
It would be better to have hindi & urdu as separate languages, since there are some differences in them.